### PR TITLE
Add CPU temperature metrics

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,11 +56,13 @@ Noderig have some built-in collectors.
 <tr><td>os.cpu.systems{}</td><td>combined percentage of cpu systems</td></tr>
 <tr><td>os.cpu.nice{}</td><td>combined percentage of cpu nice</td></tr>
 <tr><td>os.cpu.irq{}</td><td>combined percentage of cpu irq</td></tr>
+<tr><td>os.cpu.temperature{id:n}</td><td>temperature of cpu n</td></tr>
 <tr><td rowspan="5">3</td><td>os.cpu.iowait{chore:n}</td><td>chore percentage of cpu iowait</td></tr>
 <tr><td>os.cpu.user{chore:n}</td><td>chore percentage of cpu user</td></tr>
 <tr><td>os.cpu.systems{chore:n}</td><td>chore percentage of cpu systems</td></tr>
 <tr><td>os.cpu.nice{chore:n}</td><td>chore percentage of cpu nice</td></tr>
 <tr><td>os.cpu.irq{chore:n}</td><td>chore percentage of cpu irq</td></tr>
+<tr><td>os.cpu.temperature{core:n}</td><td>temperature of cpu core n</td></tr>
 </table>
 
 ### Memory

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,12 @@
-hash: 90ae868bbe36b77e6ec6be99acf815c6dfa3152b862ef81a4b4ab5ea0adda831
-updated: 2017-01-17T11:55:55.249155088-05:00
+hash: df0baffc41b71d71ea6b391f4c607f797f44cd5f63db97938833d24282191ae9
+updated: 2018-03-01T16:27:54.596542038+01:00
 imports:
 - name: github.com/fsnotify/fsnotify
   version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
+- name: github.com/go-ole/go-ole
+  version: a1ec82a652ebc7e784d7df887cfb31061aeabbcc
+  subpackages:
+  - oleutil
 - name: github.com/hashicorp/hcl
   version: 37ab263305aaeb501a60eb16863e808d426e37f2
   subpackages:
@@ -25,9 +29,20 @@ imports:
 - name: github.com/pelletier/go-toml
   version: ce7be745f09fe4ff89af8e3ea744e1deabf20ee3
 - name: github.com/shirou/gopsutil
-  version: aa5843400ec86e2ed6969e9d172e5719c08d56bf
+  version: c432be29ccce470088d07eea25b3ea7e68a8afbb
+  subpackages:
+  - cpu
+  - disk
+  - host
+  - internal/common
+  - load
+  - mem
+  - net
+  - process
+- name: github.com/shirou/w32
+  version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
 - name: github.com/Sirupsen/logrus
-  version: d26492970760ca5d33129d2d799e34be5c4782eb
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/afero
   version: 2f30b2a92c0e5700bcfe4715891adb1f2a7a406d
   subpackages:
@@ -42,10 +57,13 @@ imports:
   version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/spf13/viper
   version: 5ed0fc31f7f453625df314d8e66b9791e8d13003
+- name: github.com/StackExchange/wmi
+  version: 5d049714c4a64225c3c79a7cf7d02f7fb5b96338
 - name: golang.org/x/sys
   version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
   version: 47a200a05c8b3fd1b698571caecbb68beb2611ec
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,4 +5,4 @@ import:
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
 - package: github.com/shirou/gopsutil
-  version: ^2.16.12
+  version: ^2.18.01


### PR DESCRIPTION
This PR adds metrics for CPU temperature to noderig (in °C). The exposed metrics depend on the cpu metrics level:

* On cpu metric level 2, exposes the global temperature of each CPU
* On cpu metric level 3, exposes the temperature of each individual CPU core

Signed-off-by: Brendan Abolivier <brendan@cozycloud.cc>