### PR TITLE
Fix/gometalinter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: go
 go:
-- 1.8.x
 - 1.10.x
+- 1.11.x
 - master
 go_import_path: github.com/ovh/noderig
 before_install:
 - go get github.com/Masterminds/glide
-- go get github.com/alecthomas/gometalinter
-before_script: gometalinter --install --update
+- curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
 script:
 - glide install
 - make lint
-- make
+- make format
+- make dist
 deploy:
   provider: releases
   api_key:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,10 +5,12 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"sync"
 	"time"
 
 	"net/http"
 
+	"github.com/fsnotify/fsnotify"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -16,6 +18,9 @@ import (
 	"github.com/ovh/noderig/collectors"
 	"github.com/ovh/noderig/core"
 )
+
+var cs []core.Collector
+var csMutex = sync.Mutex{}
 
 // Aggregator init - define command line arguments.
 func init() {
@@ -35,6 +40,18 @@ func init() {
 
 	viper.BindPFlags(RootCmd.PersistentFlags())
 	viper.BindPFlags(RootCmd.Flags())
+
+	viper.WatchConfig()
+
+	viper.OnConfigChange(func(e fsnotify.Event) {
+		log.Info("Config file changed, reload...")
+
+		csMutex.Lock()
+		defer csMutex.Unlock()
+		cs = getCollectors()
+
+		log.Infof("Reloaded - %d", len(cs))
+	})
 }
 
 // Load config - initialize defaults and read config.
@@ -83,71 +100,14 @@ var RootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Info("Noderig starting")
 
-		// Build collectors
-		var cs []core.Collector
-
-		cpu := collectors.NewCPU(uint(viper.GetInt("period")), uint8(viper.GetInt("cpu")), viper.GetStringSlice("cpu-mods"))
-		cs = append(cs, cpu)
-
-		mem := collectors.NewMemory(uint(viper.GetInt("period")), uint8(viper.GetInt("mem")))
-		cs = append(cs, mem)
-
-		load := collectors.NewLoad(uint(viper.GetInt("period")), uint8(viper.GetInt("load")))
-		cs = append(cs, load)
-
-		net := collectors.NewNet(uint(viper.GetInt("period")), uint8(viper.GetInt("net")), viper.Get("net-opts"))
-		cs = append(cs, net)
-
-		disk := collectors.NewDisk(uint(viper.GetInt("period")), uint8(viper.GetInt("disk")), viper.Get("disk-opts"))
-		cs = append(cs, disk)
-
-		// Load external collectors
-		cpath := viper.GetString("collectors")
-		cdir, err := os.Open(cpath)
-		if err == nil {
-			idirs, err := cdir.Readdir(0)
-			if err != nil {
-				log.Error(err)
-				return
-			}
-			for _, idir := range idirs {
-				idirname := idir.Name()
-				i, err := strconv.Atoi(idirname)
-				if err != nil {
-					if idirname != "etc" && idirname != "lib" {
-						log.Warn("Bad collector folder: ", idirname)
-					}
-					continue
-				}
-
-				interval := i * 1000
-				if i <= 0 {
-					interval = viper.GetInt("period")
-				}
-
-				dir, err := os.Open(path.Join(cpath, idirname))
-				if err != nil {
-					log.Error(err)
-					continue
-				}
-
-				files, err := dir.Readdir(0)
-				if err != nil {
-					log.Error(err)
-					continue
-				}
-
-				for _, file := range files {
-					disk := collectors.NewCollector(path.Join(dir.Name(), file.Name()), uint(interval), uint(viper.GetInt("keep-for")))
-					cs = append(cs, disk)
-				}
-			}
-		}
+		cs = getCollectors()
 
 		log.Infof("Noderig started - %v", len(cs))
 
 		// Setup http
 		http.Handle("/metrics", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			csMutex.Lock()
+			defer csMutex.Unlock()
 			for _, c := range cs {
 				w.Write(c.Metrics().Bytes())
 			}
@@ -179,11 +139,15 @@ var RootCmd = &cobra.Command{
 							log.Errorf("Flush failed: %v", err)
 						}
 
+						csMutex.Lock()
 						for _, c := range cs {
 							file.Write(c.Metrics().Bytes())
 						}
+						csMutex.Unlock()
 
-						file.Close()
+						if err := file.Close(); err != nil {
+							log.WithError(err).Error("Cannot close flush file")
+						}
 
 						// Move tmp file to metrics one
 						log.Debugf("Move to file: %v%v", path, ".metrics")
@@ -203,4 +167,69 @@ var RootCmd = &cobra.Command{
 			select {}
 		}
 	},
+}
+
+func getCollectors() []core.Collector {
+	// Build collectors
+	var cs []core.Collector
+
+	cpu := collectors.NewCPU(uint(viper.GetInt("period")), uint8(viper.GetInt("cpu")), viper.GetStringSlice("cpu-mods"))
+	cs = append(cs, cpu)
+
+	mem := collectors.NewMemory(uint(viper.GetInt("period")), uint8(viper.GetInt("mem")))
+	cs = append(cs, mem)
+
+	load := collectors.NewLoad(uint(viper.GetInt("period")), uint8(viper.GetInt("load")))
+	cs = append(cs, load)
+
+	net := collectors.NewNet(uint(viper.GetInt("period")), uint8(viper.GetInt("net")), viper.Get("net-opts"))
+	cs = append(cs, net)
+
+	disk := collectors.NewDisk(uint(viper.GetInt("period")), uint8(viper.GetInt("disk")), viper.Get("disk-opts"))
+	cs = append(cs, disk)
+
+	// Load external collectors
+	cpath := viper.GetString("collectors")
+	cdir, err := os.Open(cpath)
+	if err == nil {
+		idirs, err := cdir.Readdir(0)
+		if err != nil {
+			log.Error(err)
+			return cs
+		}
+		for _, idir := range idirs {
+			idirname := idir.Name()
+			i, err := strconv.Atoi(idirname)
+			if err != nil {
+				if idirname != "etc" && idirname != "lib" {
+					log.Warn("Bad collector folder: ", idirname)
+				}
+				continue
+			}
+
+			interval := i * 1000
+			if i <= 0 {
+				interval = viper.GetInt("period")
+			}
+
+			dir, err := os.Open(path.Join(cpath, idirname))
+			if err != nil {
+				log.Error(err)
+				continue
+			}
+
+			files, err := dir.Readdir(0)
+			if err != nil {
+				log.Error(err)
+				continue
+			}
+
+			for _, file := range files {
+				disk := collectors.NewCollector(path.Join(dir.Name(), file.Name()), uint(interval), uint(viper.GetInt("keep-for")))
+				cs = append(cs, disk)
+			}
+		}
+	}
+
+	return cs
 }

--- a/collectors/cpu.go
+++ b/collectors/cpu.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
+	log "github.com/sirupsen/logrus"
 )
 
 // CPU collects cpu related metrics
@@ -33,9 +33,9 @@ func NewCPU(period uint, level uint8, modules []string) *CPU {
 		return c
 	}
 
-	tick := time.Tick(time.Duration(period) * time.Millisecond)
+	tick := time.NewTicker(time.Duration(period) * time.Millisecond)
 	go func() {
-		for range tick {
+		for range tick.C {
 			if err := c.scrape(); err != nil {
 				log.Error(err)
 			}

--- a/collectors/disk.go
+++ b/collectors/disk.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/shirou/gopsutil/disk"
+	log "github.com/sirupsen/logrus"
 )
 
 // Disk collects disk related metrics
@@ -45,9 +45,9 @@ func NewDisk(period uint, level uint8, opts interface{}) *Disk {
 	}
 
 	if level > 0 {
-		tick := time.Tick(time.Duration(period) * time.Millisecond)
+		tick := time.NewTicker(time.Duration(period) * time.Millisecond)
 		go func() {
-			for range tick {
+			for range tick.C {
 				if err := c.scrape(); err != nil {
 					log.Error(err)
 				}

--- a/collectors/load.go
+++ b/collectors/load.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/shirou/gopsutil/load"
+	log "github.com/sirupsen/logrus"
 )
 
 // Load collects load related metrics
@@ -27,9 +27,9 @@ func NewLoad(period uint, level uint8) *Load {
 		return c
 	}
 
-	tick := time.Tick(time.Duration(period) * time.Millisecond)
+	tick := time.NewTicker(time.Duration(period) * time.Millisecond)
 	go func() {
-		for range tick {
+		for range tick.C {
 			if err := c.scrape(); err != nil {
 				log.Error(err)
 			}

--- a/collectors/memory.go
+++ b/collectors/memory.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/shirou/gopsutil/mem"
+	log "github.com/sirupsen/logrus"
 )
 
 // Memory collects memory related metrics
@@ -27,9 +27,9 @@ func NewMemory(period uint, level uint8) *Memory {
 		return c
 	}
 
-	tick := time.Tick(time.Duration(period) * time.Millisecond)
+	tick := time.NewTicker(time.Duration(period) * time.Millisecond)
 	go func() {
-		for range tick {
+		for range tick.C {
 			if err := c.scrape(); err != nil {
 				log.Error(err)
 			}

--- a/collectors/net.go
+++ b/collectors/net.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/shirou/gopsutil/net"
+	log "github.com/sirupsen/logrus"
 )
 
 // Net collects network related metrics
@@ -49,9 +49,9 @@ func NewNet(period uint, level uint8, opts interface{}) *Net {
 		return c
 	}
 
-	tick := time.Tick(time.Duration(period) * time.Millisecond)
+	tick := time.NewTicker(time.Duration(period) * time.Millisecond)
 	go func() {
-		for range tick {
+		for range tick.C {
 			if err := c.scrape(); err != nil {
 				log.Error(err)
 			}
@@ -87,8 +87,8 @@ func (c *Net) scrape() error {
 		in += cnt.BytesRecv
 		out += cnt.BytesSent
 	}
-	in = in / uint64(c.period/1000)
-	out = out / uint64(c.period/1000)
+	in /= uint64(c.period / 1000)
+	out /= uint64(c.period / 1000)
 
 	// protect consistency
 	c.mutex.Lock()


### PR DESCRIPTION
Gometalinter is now deprecated, the advice is to switch to golangci-lint.
This is the PR which make the switch.

The switch involved some code refactoring