### PR TITLE
feat(collectors): allow @ char as a tag value for custom collectors

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	version = "2.5.3"
+	version = "2.5.4"
 	githash = "HEAD"
 )
 

--- a/collectors/collector.go
+++ b/collectors/collector.go
@@ -113,7 +113,8 @@ func (c *Collector) scrape() (cmdError error) {
 		ew.Close()
 	}()
 
-	tagPattern := regexp.MustCompile(`^[a-zA-Z0-9-%_\.\/]*$`)
+	tagKeyPattern := regexp.MustCompile(`^[a-zA-Z0-9-%_\.\/]*$`)
+	tagValuePattern := regexp.MustCompile(`^[a-zA-Z0-9-%_@\.\/]*$`)
 
 	// Stderr handler
 	go func() {
@@ -178,7 +179,7 @@ func (c *Collector) scrape() (cmdError error) {
 				if len(sp) != 2 {
 					break
 				}
-				if !tagPattern.MatchString(sp[0]) || !tagPattern.MatchString(sp[1]) {
+				if !tagKeyPattern.MatchString(sp[0]) || !tagValuePattern.MatchString(sp[1]) {
 					break
 				}
 				dp.Tags[c.sanitize(sp[0])] = c.sanitize(sp[1])


### PR DESCRIPTION
Hi!

Found an issue where '@' char was not allowed as an actual label value.

As we are compatible with prom, and according to the Prometheus documentation:

> Label names may contain ASCII letters, numbers, as well as underscores. They must match the regex [a-zA-Z_][a-zA-Z0-9_]*. Label names beginning with __ are reserved for internal use.

> Label values may contain any Unicode characters.

This PR is splitting regexp for key and value, and allow '@' as a char.